### PR TITLE
add new methods from Monero 0.13.x

### DIFF
--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -778,6 +778,49 @@ class daemonRPC {
   }
 
   /**
+   * Ban or unban a peer
+   *
+   * @function set_bans
+   * @param {array} bans - Array of hosts objects to ban with the following parameters:
+   *   @param {string} host - Host to ban in 'A.B.C.D' form
+   *   @param {boolean} ban - True to ban node, false to unban
+   *   @param {number} seconds - Duration of ban in seconds
+   *
+   * @returns {object} - Example: {
+   *   status: 'OK'
+   * }
+   */
+  set_bans(bans) {
+    let params = { bans: bans };
+    return this._run('set_bans', params);
+  }
+
+  /**
+   * Look up list of banned peers
+   *
+   * @function get_bans
+   *
+   * @returns {object} - Example: {
+   *   status: 'OK'
+   * }
+   */
+  get_bans() {
+    return this._run('get_bans');
+  }
+
+  /**
+   * Flush (empty) transaction pool ("mempool")
+   *
+   * @function flush_txpool
+   *
+   * @returns {object} - Example: {
+   *   status: 'OK'
+   * }
+   */
+  flush_txpool() {
+    return this._run('flush_txpool');
+  }
+  
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -890,6 +890,45 @@ class daemonRPC {
   }
 
   /**
+   * Look up synchronization information
+   *
+   * @function sync_info
+   * 
+   * @returns {object} - Example: {
+   *   height: 1180052,
+   *   peers: [
+   *     info: {
+   *       address: '212.83.172.165:28080',
+   *       avg_download: 0,
+   *       avg_upload: 0,
+   *       connection_id: 'c94564f7a27795b888ec08c8e004beae',
+   *       current_download: 0,
+   *       current_upload: 0,
+   *       height: 0,
+   *       host: '212.83.172.165',
+   *       incoming: false,
+   *       ip: '212.83.172.165',
+   *       live_time: 1,
+   *       local_ip: false,
+   *       localhost: false,
+   *       peer_id: '0',
+   *       port: '28080',
+   *       recv_count: 0,
+   *       recv_idle_time: 1,
+   *       send_count: 259,
+   *       send_idle_time: 1,
+   *       state: 'before_handshake',
+   *       support_flags: 0
+   *    }...],
+   *    status: 'OK',
+   *    target_height: 1179850
+   * }
+   */
+  sync_info() {
+    return this._run('sync_info');
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -838,6 +838,28 @@ class daemonRPC {
   }
 
   /**
+   * Look up coinbase reward sum from a certain start height
+   *
+   * @function get_version
+   * @param {number} height - Block height at which to start summing
+   * @param {number} count - Number of blocks' coinbase rewards to sum (starting from the height specified above)
+   *
+   * @returns {object} - Example: {
+   *   emission_amount: 175921105471352, 
+   *   fee_amount: 0,
+   *   status: 'OK'
+   * } 
+   */
+  get_coinbase_tx_sum(height, count) {
+    let params = {
+      height: height,
+      count: count
+    };
+
+    return this._run('get_coinbase_tx_sum', params);
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -877,6 +877,19 @@ class daemonRPC {
   }
 
   /**
+   * Look up alternate chains
+   *
+   * @function get_alternate_chains
+   * 
+   * @returns {object} - Example: {
+   *   status: 'OK'
+   * } // TODO expand example by showing alternate change
+   */
+  get_alternate_chains() {
+    return this._run('get_alternate_chains');
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -301,7 +301,7 @@ class daemonRPC {
    *
    * @returns {object} - Example: {  
    *   count: 993163,  
-   *   status: "OK"  
+   *   status: 'OK'  
    * }  
    */
   getblockcount() {
@@ -357,12 +357,12 @@ class daemonRPC {
    * @param {int} reserve_size - Reserve size 
    *
    * @returns {object} - Example: {
-   *   blocktemplate_blob: "01029af88cb70568b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed83000000000018bd03c01ffcfcf3c0493d7cec7020278dfc296544f139394e5e045fcda1ba2cca5b69b39c9ddc90b7e0de859fdebdc80e8eda1ba01029c5d518ce3cc4de26364059eadc8220a3f52edabdaf025a9bff4eec8b6b50e3d8080dd9da417021e642d07a8c33fbe497054cfea9c760ab4068d31532ff0fbb543a7856a9b78ee80c0f9decfae01023ef3a7182cb0c260732e7828606052a0645d3686d7a03ce3da091dbb2b75e5955f01ad2af83bce0d823bf3dbbed01ab219250eb36098c62cbb6aa2976936848bae53023c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001f12d7c87346d6b84e17680082d9b4a1d84e36dd01bd2c7f3b3893478a8d88fb3",
+   *   blocktemplate_blob: '01029af88cb70568b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed83000000000018bd03c01ffcfcf3c0493d7cec7020278dfc296544f139394e5e045fcda1ba2cca5b69b39c9ddc90b7e0de859fdebdc80e8eda1ba01029c5d518ce3cc4de26364059eadc8220a3f52edabdaf025a9bff4eec8b6b50e3d8080dd9da417021e642d07a8c33fbe497054cfea9c760ab4068d31532ff0fbb543a7856a9b78ee80c0f9decfae01023ef3a7182cb0c260732e7828606052a0645d3686d7a03ce3da091dbb2b75e5955f01ad2af83bce0d823bf3dbbed01ab219250eb36098c62cbb6aa2976936848bae53023c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001f12d7c87346d6b84e17680082d9b4a1d84e36dd01bd2c7f3b3893478a8d88fb3',
    *   difficulty: 982540729,
    *   height: 993231,
-   *   prev_hash: "68b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed830",
+   *   prev_hash: '68b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed830',
    *   reserved_offset: 246,
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   getblocktemplate(wallet_address, reserve_size) {
@@ -464,17 +464,17 @@ class daemonRPC {
    *   block_header: {
    *     depth: 0,
    *     difficulty: 746963928,
-   *     hash: "ac0f1e226268d45c99a16202fdcb730d8f7b36ea5e5b4a565b1ba1a8fc252eb0",
+   *     hash: 'ac0f1e226268d45c99a16202fdcb730d8f7b36ea5e5b4a565b1ba1a8fc252eb0',
    *     height: 990793,
    *     major_version: 1,
    *     minor_version: 1,
    *     nonce: 1550,
    *     orphan_status: false,
-   *     prev_hash: "386575e3b0b004ed8d458dbd31bff0fe37b280339937f971e06df33f8589b75c",
+   *     prev_hash: '386575e3b0b004ed8d458dbd31bff0fe37b280339937f971e06df33f8589b75c',
    *     reward: 6856609225169,
    *     timestamp: 1457589942
    *   },
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   getlastblockheader() {
@@ -502,17 +502,17 @@ class daemonRPC {
    *   block_header: {
    *     depth: 78376,
    *     difficulty: 815625611,
-   *     hash: "e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6",
+   *     hash: 'e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6',
    *     height: 912345,
    *     major_version: 1,
    *     minor_version: 2,
    *     nonce: 1646,
    *     orphan_status: false,
-   *     prev_hash: "b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78",
+   *     prev_hash: 'b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78',
    *     reward: 7388968946286,
    *     timestamp: 1452793716
    *   },
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   getblockheaderbyhash(hash) {
@@ -546,17 +546,17 @@ class daemonRPC {
    *   block_header: {
    *     depth: 78376,
    *     difficulty: 815625611,
-   *     hash: "e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6",
+   *     hash: 'e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6',
    *     height: 912345,
    *     major_version: 1,
    *     minor_version: 2,
    *     nonce: 1646,
    *     orphan_status: false,
-   *     prev_hash: "b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78",
+   *     prev_hash: 'b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78',
    *     reward: 7388968946286,
    *     timestamp: 1452793716
    *   },
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   getblockheaderbyheight(height) {
@@ -606,7 +606,7 @@ class daemonRPC {
    *     },
    *     ...
    *   ],
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   getblockheadersrange(start_height, end_height) {
@@ -644,22 +644,22 @@ class daemonRPC {
    * @param {string} hash - The block's SHA256 hash
    *
    * @returns {object} - Example: {
-   *   blob: "...",
+   *   blob: '..."'
    *   block_header: {
    *     depth: 12,
    *     difficulty: 964985344,
-   *     hash: "510ee3c4e14330a7b96e883c323a60ebd1b5556ac1262d0bc03c24a3b785516f",
+   *     hash: '510ee3c4e14330a7b96e883c323a60ebd1b5556ac1262d0bc03c24a3b785516f',
    *     height: 993056,
    *     major_version: 1,
    *     minor_version: 2,
    *     nonce: 2036,
    *     orphan_status: false,
-   *     prev_hash: "0ea4af6547c05c965afc8df6d31509ff3105dc7ae6b10172521d77e09711fd6d",
+   *     prev_hash: '0ea4af6547c05c965afc8df6d31509ff3105dc7ae6b10172521d77e09711fd6d',
    *     reward: 6932043647005,
    *     timestamp: 1457720227
    *   },
-   *   json: "...",
-   *   status: "OK"
+   *   json: '..."'
+   *   status: 'OK'
    * }
    */
   getblock_by_hash(hash) {
@@ -675,22 +675,22 @@ class daemonRPC {
    * @param {int} height - The block's height
    *
    * @returns {object} - Example: {
-   *   blob: "...",
+   *   blob: '..."'
    *   block_header: {
    *     depth: 80694,
    *     difficulty: 815625611,
-   *     hash: "e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6",
+   *     hash: 'e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6',
    *     height: 912345,
    *     major_version: 1,
    *     minor_version: 2,
    *     nonce: 1646,
    *     orphan_status: false,
-   *     prev_hash: "b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78",
+   *     prev_hash: 'b61c58b2e0be53fad5ef9d9731a55e8a81d972b8d90ed07c04fd37ca6403ff78',
    *     reward: 7388968946286,
    *     timestamp: 1452793716
    *   },
-   *   json: "...",
-   *   status: "OK"
+   *   json: '..."'
+   *   status: 'OK'
    * }
    */
   getblock_by_height(height) {
@@ -710,21 +710,21 @@ class daemonRPC {
    *     current_download: 0,
    *     current_upload: 0,
    *     incoming: false,
-   *     ip: "76.173.170.133",
+   *     ip: '76'173.170.133",
    *     live_time: 1865,
    *     local_ip: false,
    *     localhost: false,
-   *     peer_id: "3bfe29d6b1aa7c4c",
-   *     port: "18080",
+   *     peer_id: '3bfe29d6b1aa7c4c',
+   *     port: '18080',
    *     recv_count: 116396,
    *     recv_idle_time: 23,
    *     send_count: 176893,
    *     send_idle_time: 1457726610,
-   *     state: "state_normal"
+   *     state: 'state_normal'
    *   },{
    *   ...
    *   }],
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   get_connections() {
@@ -737,7 +737,7 @@ class daemonRPC {
    * @function get_info
    *
    * @returns {object} - Example: {
-   *   status: "OK" // TODO add example result
+   *   status: 'OK' // TODO add example result
    * }
    */
   get_info() {
@@ -784,7 +784,7 @@ class daemonRPC {
    *
    * @returns {object} - Example: {
    *   height: 1637538,
-   *   status: "OK",
+   *   status: 'OK',
    *   untrusted: false
    * }
    * 
@@ -863,7 +863,7 @@ class daemonRPC {
    *     "b1c51d7e224aabb30a03764f0faca5386e6566fc7463612048f7676e6af077fe",
    *     ...
    *   ],
-   *   status: "OK",
+   *   status: 'OK',
    *   untrusted: false
    * }
    */
@@ -881,7 +881,7 @@ class daemonRPC {
    *
    * @returns {object} - Example: {
    *   spent_status: [ 1 ],
-   *   status: "OK",
+   *   status: 'OK',
    *   untrusted: false
    * }
    */
@@ -900,7 +900,7 @@ class daemonRPC {
    * @function stop_daemon
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   stop_daemon() {
@@ -916,7 +916,7 @@ class daemonRPC {
    * @returns {object} - Example: {
    *   limit_down: 8192,
    *   limit_up: 2048,
-   *   status: "OK",
+   *   status: 'OK',
    *   untrusted: false
    * }
    */
@@ -935,7 +935,7 @@ class daemonRPC {
    * @returns {object} - Example: {
    *   limit_down: 8192,
    *   limit_up: 2048,
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   set_limit(limit_down = 0, limit_up = 0) {
@@ -955,7 +955,7 @@ class daemonRPC {
    * @param {number} out_peers - Maximum number of outgoing peers
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   out_peers(out_peers) {
@@ -974,7 +974,7 @@ class daemonRPC {
    * @param {number} in_peers - Maximum number of incoming peers
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   in_peers(in_peers) {
@@ -1001,8 +1001,8 @@ class daemonRPC {
    *   not_rct: false,
    *   not_relayed: false,
    *   overspend: false,
-   *   reason: "",
-   *   status: "OK"
+   *   reason: '"'
+   *   status: 'OK'
    *   too_big: false,
    *   untrusted: false
    * }
@@ -1038,7 +1038,7 @@ class daemonRPC {
    * @param {number} threads_count - Number of threads with which to mine
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   start_mining(do_background_mining, ignore_battery, miner_address, threads_count) {
@@ -1059,7 +1059,7 @@ class daemonRPC {
    * @function stop_mining
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   stop_mining() {
@@ -1074,10 +1074,10 @@ class daemonRPC {
    *
    * @returns {object} - Example: {
    *   active: true,
-   *   address: "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A",
+   *   address: '44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A',
    *   is_background_mining_enabled: false,
    *   speed: 20,
-   *   status: "OK",
+   *   status: 'OK',
    *   threads_count: 1
    * }
    */
@@ -1092,7 +1092,7 @@ class daemonRPC {
    * @function save_bc
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   save_bc() {
@@ -1106,7 +1106,7 @@ class daemonRPC {
    * @function get_peer_list
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   get_peer_list() {
@@ -1121,7 +1121,7 @@ class daemonRPC {
    * @param {boolean} visible - Set hash rate log visibility
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   set_log_hash_rate(visible) {
@@ -1140,7 +1140,7 @@ class daemonRPC {
    * @param {number} visible - Set log verbosity from 0 (less verbose) to 4 (most verbose)
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   set_log_level(level) {
@@ -1212,7 +1212,7 @@ class daemonRPC {
    * @param {string} categories - Comma-separated list of log level categories and levels
    *
    * @returns {object} - Example: {
-   *   status: "OK"
+   *   status: 'OK'
    * }
    */
   set_log_categories(categories) {
@@ -1230,7 +1230,7 @@ class daemonRPC {
    * @function get_transaction_pool
    *
    * @returns {object} - Example: {
-   *   status: "OK" // TODO add more exhaustive example
+   *   status: 'OK' // TODO add more exhaustive example
    * }
    */
   get_transaction_pool() {
@@ -1244,7 +1244,7 @@ class daemonRPC {
    * @function get_transaction_pool_hashes
    *
    * @returns {object} - Example: {
-   *   status: "OK" // TODO add more exhaustive example
+   *   status: 'OK' // TODO add more exhaustive example
    * }
    */
   get_transaction_pool_hashes() {
@@ -1264,7 +1264,7 @@ class daemonRPC {
    *     bytes_min: 13092,
    *     bytes_total: 107390,
    *     fee_total: 47380940000,
-   *     histo: "\\b�K���7�N䏑�B��\\n0$3}�\\\"���kX��",
+   *     histo: '\\b�K���7�N䏑�B��'\n0$3}�\\\"���kX��",
    *     histo_98pc: 0,
    *     num_10m: 4,
    *     num_double_spends: 0,
@@ -1273,7 +1273,7 @@ class daemonRPC {
    *     oldest: 1534112886,
    *     txs_total: 8
    *   },
-   *   status: "OK",
+   *   status: 'OK',
    *   untrusted: false
    * }
    */

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -397,9 +397,9 @@ class daemonRPC {
    * Submit a mined block to the network
    *
    * @function submitblock
-   * @param {string} block - Block blob data string
+   * @param {array} block - Array of block blob data strings
    *
-   * @return string  // TODO: example
+   * @return object - Example: // TODO: example
    */
   submitblock(block) {
     if (typeof block == 'undefined') {
@@ -417,7 +417,42 @@ class daemonRPC {
    * @returns {object}
    */
   submit_block(block) {
-    return this.submitblock(block);
+    return this.submitblock([block]);
+  }
+
+  /**
+   * Generate blocks (not available on mainnet)
+   *
+   * @function generateblocks
+   * @param {string} wallet_address - Address of wallet to receive coinbase transactions if block is successfully mined
+   * @param {number} reserve_size - Reserve size 
+   * @param {number} amount_of_blocks - Number of blocks to generate (default: 1)
+   *
+   * @returns {object} - Example: {
+   *   blocktemplate_blob: '01029af88cb70568b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed83000000000018bd03c01ffcfcf3c0493d7cec7020278dfc296544f139394e5e045fcda1ba2cca5b69b39c9ddc90b7e0de859fdebdc80e8eda1ba01029c5d518ce3cc4de26364059eadc8220a3f52edabdaf025a9bff4eec8b6b50e3d8080dd9da417021e642d07a8c33fbe497054cfea9c760ab4068d31532ff0fbb543a7856a9b78ee80c0f9decfae01023ef3a7182cb0c260732e7828606052a0645d3686d7a03ce3da091dbb2b75e5955f01ad2af83bce0d823bf3dbbed01ab219250eb36098c62cbb6aa2976936848bae53023c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001f12d7c87346d6b84e17680082d9b4a1d84e36dd01bd2c7f3b3893478a8d88fb3',
+   *   difficulty: 982540729,
+   *   height: 993231,
+   *   prev_hash: '68b84a11dc9406ace9e635918ca03b008f7728b9726b327c1b482a98d81ed830',
+   *   reserved_offset: 130,
+   *   status: 'OK'
+   * }
+   */
+  generateblocks(wallet_address, reserve_size, amount_of_blocks = 1) {
+    if (typeof wallet_address == 'undefined') {
+      throw new Error('Error: Wallet address required');
+    }
+    if (typeof reserve_size == 'undefined') {
+      throw new Error('Error: Reserve size required');
+    }
+    
+    let params = {
+      wallet_address: wallet_address,
+      reserve_size: reserve_size,
+      amount_of_blocks: amount_of_blocks,
+      decode_as_json: true
+    };
+
+    return this._run('getblocktemplate', params);
   }
 
   /**

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -821,6 +821,23 @@ class daemonRPC {
     return this._run('flush_txpool');
   }
   
+  /**
+  /**
+   * Look up node's version
+   *
+   * @function get_version
+   *
+   * @returns {object} - Example: {
+   *   status: 'OK',
+   *   untrusted: false,
+   *   version: 65557
+   * } 
+   */
+  get_version() {
+    return this._run('get_version');
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight
@@ -830,7 +847,6 @@ class daemonRPC {
    *   status: 'OK',
    *   untrusted: false
    * }
-   * 
    */
   getheight() {
     let params = { decode_as_json: true };

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -1190,7 +1190,7 @@ class daemonRPC {
   }
 
   /**
-   * Look up transaction ("mempool") pool information
+   * Look up transaction pool ("mempool") information
    *
    * @function get_transaction_pool
    *
@@ -1204,7 +1204,21 @@ class daemonRPC {
   }
 
   /**
-   * Look up transaction ("mempool") pool information
+   * Look up hashes of transactions in pool ("mempool") 
+   *
+   * @function get_transaction_pool_hashes
+   *
+   * @returns {object} - Example: {
+   *   status: "OK" // TODO add more exhaustive example
+   * }
+   */
+  get_transaction_pool_hashes() {
+    let params = { decode_as_json: true };
+    return this._run(null, params, 'get_transaction_pool');
+  }
+
+  /**
+   * Look up transaction pool ("mempool") statistics
    *
    * @function get_transaction_pool_stats
    *

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -822,6 +822,31 @@ class daemonRPC {
   }
   
   /**
+   * Look up histogram of output amounts. For all amounts (possibly filtered by parameters,) gives the number of outputs on the chain for that amount. RingCT outputs counts as 0 amount.
+   *
+   * @function get_output_histogram
+   * @param {array} amounts - Look up output amounts under this amount
+   * @param {number} min_count - The minimum outputs to return
+   * @param {number} max_count - The maximum outputs to return
+   * @param {boolean} unlocked - Only return unlocked outputs
+   * @param {number} recent_cutoff - Do not include outputs from this number of blocks
+   *
+   * @returns {object} - Example: {
+   *
+   * }
+   */
+  get_output_histogram(amounts, min_count, max_count, unlocked, recent_cutoff) {
+    let params = {
+      amounts: amounts,
+      min_count: min_count,
+      max_count: max_count,
+      unlocked: unlocked,
+      recent_cutoff: recent_cutoff
+    };
+
+    return this._run('get_output_histogram');
+  }
+
   /**
    * Look up node's version
    *

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -860,6 +860,23 @@ class daemonRPC {
   }
 
   /**
+   * Look up fee estimate in atomic units per kilobyte
+   *
+   * @function get_fee_estimate
+   * @param {number} grace_blocks - Number of blocks to include in fee estimation window
+   *
+   * @returns {object} - Example: {
+   *   fee: 268950000,
+   *   status: 'OK',
+   *   untrusted: false
+   * }
+   */
+  get_fee_estimate(grace_blocks) {
+    let params = { grace_blocks: grace_blocks };
+    return this._run('get_fee_estimate', params);
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -929,6 +929,32 @@ class daemonRPC {
   }
 
   /**
+   * Look up output distribution within a range of blocks
+   *
+   * @function getheight
+   * @param {array} amounts - Array of amounts to look for
+   * @param {boolean} cumulative - Should result be cumulative?   (default: false)
+   * @param {number} from_height - Block height to start analysis (default: 0)
+   * @param {number} to_height - Block height to end analysis     (default: 0)
+   *
+   * @returns {object} - Example: {
+   *   height: 1637538,
+   *   status: 'OK',
+   *   untrusted: false
+   * }
+   */
+  get_output_distribution(amounts, cumulative = false, from_height = 0, to_height = 0) {
+    let params = {
+      amounts: amounts,
+      cumulative: cumulative,
+      from_height: from_height,
+      to_height: to_height
+    };
+
+    return this._run('get_output_distribution', params);
+  }
+
+  /**
    * Look up node's current height
    *
    * @function getheight

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -1249,7 +1249,6 @@ class daemonRPC {
    *    status: 'OK',
    *    untrusted: false }
    * }
-   * 
    */
   get_outs(outputs) {
     let params = {
@@ -1276,7 +1275,6 @@ class daemonRPC {
    *   user_uri: '',
    *   version: ''
    * }
-   * 
    */
   update(command, path) {
     let params = {

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -929,6 +929,20 @@ class daemonRPC {
   }
 
   /**
+   * Look up transaction pool ("mempool") backlog
+   *
+   * @function get_txpool_backlog
+   *
+   * @returns {object} - Example: {
+   *   status: 'OK',
+   *   untrusted: false
+   * } // TODO expand example by showing backlog
+   */
+  get_txpool_backlog() {
+    return this._run('get_txpool_backlog');
+  }
+
+  /**
    * Look up output distribution within a range of blocks
    *
    * @function getheight

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -933,6 +933,9 @@ class walletRPC {
       });
     });
   }
+
+  // TODO sign_transfer
+  // TODO submit_transfer
   
   /**
    * Send all dust outputs back to the wallet to make them easier to spend (and mix)

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -2284,6 +2284,20 @@ class walletRPC {
     let params = { tx_data_hex: tx_data_hex };
     return this._run('submit_multisig', params);
   }
+  
+  /**
+   * Get wallet version
+   * Version is formatted as `Major * 2^16 + Minor` (Major encoded over the first 16 bits, and Minor over the last 16 bits)
+   *
+   * @function get_version
+   *
+   * @returns - Example: {
+   *   version: 65539
+   * }
+   */
+  get_version() {
+    return this._run('get_version');
+  }
 }
 
 module.exports = walletRPC;

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -420,7 +420,9 @@ class walletRPC {
    * Label an address
    *
    * @function label_address
-   * @param {object} index - major (account) and minor (subaddress) indices to label
+   * @param {object} index - Indices to label.  An object with the following parameters:
+   *   @param {number} major - Wallet account to label
+   *   @param {number} minor - Wallet subaddress to label
    * @param {string} label - Label to apply
    *
    * Example index parameter: index: {major: 0, minor: 5}

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -2091,8 +2091,8 @@ class walletRPC {
    * Open a wallet
    *
    * @function open_wallet
-   * @param {string} filename - Filename to use for new wallet
-   * @param {string} password - Password to use for new wallet
+   * @param {string} filename - Filename to use for new wallet (default: 'monero_wallet')
+   * @param {string} password - Password to use for new wallet (default: '')
    */
   open_wallet(filename = 'monero_wallet', password = undefined) {
     let params = {
@@ -2101,6 +2101,22 @@ class walletRPC {
     };
 
     return this._run('open_wallet', params);
+  }
+  
+  /**
+   * Change wallet password
+   *
+   * @function change_wallet_password
+   * @param {string} old_password - Old/current wallet password to change
+   * @param {string} new_password - New wallet password to set
+   */
+  change_wallet_password(old_password, new_password) {
+    let params = {
+      old_password: old_password,
+      new_password: new_password
+    };
+
+    return this._run('change_wallet_password', params);
   }
   
   /**

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -363,6 +363,25 @@ class walletRPC {
   }
   
   /**
+   * Look up index of address
+   *
+   * @function get_address_index
+   * @param {string} address - Address to look up
+   *
+   * @returns {object} - Example: {
+   *   index: {
+   *     major: 0,
+   *     minor: 43
+   *   }
+   * }
+   */
+  get_address_index(address) {
+    let params = { address: address };
+
+    return this._run('get_address_index', params);
+  }
+  
+  /**
    * Create a new subaddress
    *
    * @function create_address

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -1558,7 +1558,7 @@ class walletRPC {
    * @param {string} txid - Transaction ID
    * @param {string} signature - Signature (tx_proof)
    *
-   * @returns   Example: {
+   * @returns - Example: {
    *   confirmations: 2,
    *   good: 1,
    *   in_pool: ,
@@ -1626,7 +1626,7 @@ class walletRPC {
    * @param {number} amount - Amount of reserves to prove                     (ignored if all parameter set to true)
    * @param {string} message - Message to include in reserve proof signature  (optional)
    *
-   * @returns   Example: {
+   * @returns - Example: {
    *   signature: "ReserveProofV11BZ23sBt9sZJeGccf84mzyAmNCP3KzYbE111111111111AjsVgKzau88VxXVGACbYgPVrDGC84vBU61Gmm2eiYxdZULAE4yzBxT1D9epWgCT7qiHFvFMbdChf3CpR2YsZj8CEhp8qDbitsfdy7iBdK6d5pPUiMEwCNsCGDp8AiAc6sLRiuTsLEJcfPYEKe"
    * }
    */
@@ -2211,7 +2211,7 @@ class walletRPC {
    * @function import_multisig_info
    * @param {array} info - Array of multisig info strings (from eg. prepare_multisig)
    *
-   * @returns   Example: {
+   * @returns - Example: {
    *   n_outputs: 5
    * }
    */
@@ -2241,7 +2241,7 @@ class walletRPC {
    * @param {array} multisig_info - Array of multisignature info strings (from eg. prepare_multisig)
    * @param {string} password - Passphrase to apply to multisig address (default: '')
    *
-   * @returns   Example: {
+   * @returns - Example: {
    *   address: '9v8xvJkkj9ZWLykFxh3X3v6w3nEgSVoHyXaWnd5zwz4h2jtUDk3enseWjq4BJNa8eBBqBVLwxj5KhfGhsMS8oDDHNbAULfc'
    * }
    */
@@ -2276,7 +2276,7 @@ class walletRPC {
    * @function 
    * @param {string} tx_data_hex - Transaction as hex blob
    *
-   * @returns   Example: {
+   * @returns - Example: {
    *   tx_hash_list: ['7e38dfa8163afd3602151c1c8ba48761e80855a990352d3075f9b3d689d01f78']
    * }
    */

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -1991,6 +1991,22 @@ class walletRPC {
   }
   
   /**
+   * Refresh wallet
+   *
+   * @function refresh
+   * @param {number} start_height - Height at which to start refresh (default: 0)
+   *
+   * @returns {object} - Example: {
+   *   blocks_fetched: 1,
+   *   received_money: false
+   * }
+   */
+  refresh(start_height = 0) {
+    let params = { start_height: start_height };
+    return this._run('refresh', params);
+  }
+  
+  /**
    * Rescan the blockchain for spent outputs
    * 
    * @function rescan_spent

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -1783,6 +1783,34 @@ class walletRPC {
 
     return this._run('get_transfer_by_txid', params);
   }
+
+  /**
+   * Export wallet outputs
+   *
+   * @function export_outputs
+   *
+   * @returns {object} - Example: {
+   *   outputs_data_hex: '4ea0...'
+   * }
+   */
+  export_outputs() {
+    return this._run('export_outputs');
+  }
+
+  /**
+   * Import wallet outputs
+   *
+   * @function import_outputs
+   * @param {string} outputs_data_hex - Outputs to import as a hex string
+   *
+   * @returns {object} - Example: {
+   *   num_imported: 87
+   * }
+   */
+  import_outputs(outputs_data_hex) {
+    let params = { outputs_data_hex: outputs_data_hex };
+    return this._run('import_outputs', params);
+  }
   
   /**
    * Sign a string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monerojs",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "ES6 JavaScript Monero library",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monerojs",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "ES6 JavaScript Monero library",
   "main": "index.js",
   "scripts": {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -869,6 +869,32 @@ describe('walletRPC constructor', () => {
           .timeout(6000);
         });
 
+        let outputs_data_hex = '';
+
+        describe('export_outputs()', () => {
+          it('should export wallet outputs', done => {
+            walletRPC.export_outputs()
+            .then(result => {
+              result.should.be.a.Object();
+              result.outputs_data_hex.should.be.a.String();
+              outputs_data_hex = result.outputs_data_hex;
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('import_outputs()', () => {
+          it('should import wallet outputs', done => {
+            walletRPC.import_outputs(outputs_data_hex)
+            .then(result => {
+              result.should.be.a.Object();
+              result.num_imported.should.be.a.Number();
+            })
+            .then(done, done);
+          })
+          .timeout(6000);
+        });
+
         let balance = 0;
 
         describe('getbalance()', () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -174,52 +174,6 @@ describe('daemonRPC constructor', () => {
           });
         });
 
-        let block_blob = '';
-
-        describe('generateblocks()', () => {
-          let address = '';
-          if (network == 'mainnet') {
-            address = '44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A';
-          } else if (network == 'testnet') {
-            address = '9sykYqd8soGa9Fv8zDMdt2gN8z2Aj5qQeBNpXjxRowkyCoWCYxa3xumYQe5MmQJuFN5CVTQwK2gqtfBNsFqa16gp1L4uGBU';
-          } else if (network == 'stagenet') {
-            address = '56Gpz2CeLbq1KT6eTHCqH43StT8kh7WQs9ji8wmECS7WUAx85FHrRztebp48wgEt6kcRbTpvBhnktEyDHVhe7xjbTAzALiY';
-          }
-
-          it('should generate a block', done => {
-            daemonRPC.generateblocks(address, 255, 1)
-            .then(result => {
-              result.should.be.a.Object();
-              result.status.should.be.a.String();
-              result.status.should.be.equal('OK');
-              result.blockhashing_blob.should.be.a.String();
-              result.blocktemplate_blob.should.be.a.String();
-              block_blob = result.blocktemplate_blob;
-              result.difficulty.should.be.a.Number();
-              result.expected_reward.should.be.a.Number();
-              result.height.should.be.a.Number();
-              result.prev_hash.should.be.a.String();
-              result.reserved_offset.should.be.a.Number();
-              result.untrusted.should.be.a.Boolean();
-            })
-            .then(done, done);
-          });
-        });
-
-        // Would work, but generateblocks() doesn't do proper hashing on blocks.
-        // describe('submit_block()', () => {
-        //   it('should submit a block', done => {
-        //     daemonRPC.submit_block(block_blob)
-        //     .then(result => {
-        //       result.should.be.a.Object();
-        //       console.log(result);
-        //       result.status.should.be.a.String();
-        //       result.status.should.be.eqaul('OK');
-        //     })
-        //     .then(done, done);
-        //   });
-        // });
-
         describe('getlastblockheader()', () => {
           it('should return block header', done => {
             daemonRPC.getlastblockheader()
@@ -580,6 +534,91 @@ describe('daemonRPC constructor', () => {
               .then(done, done);
             });
           });
+
+          let block_blob = '';
+
+          describe('generateblocks()', () => {
+            let address = '';
+            if (network == 'mainnet') {
+              address = '44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A';
+            } else if (network == 'testnet') {
+              address = '9sykYqd8soGa9Fv8zDMdt2gN8z2Aj5qQeBNpXjxRowkyCoWCYxa3xumYQe5MmQJuFN5CVTQwK2gqtfBNsFqa16gp1L4uGBU';
+            } else if (network == 'stagenet') {
+              address = '56Gpz2CeLbq1KT6eTHCqH43StT8kh7WQs9ji8wmECS7WUAx85FHrRztebp48wgEt6kcRbTpvBhnktEyDHVhe7xjbTAzALiY';
+            }
+
+            it('should generate a block', done => {
+              daemonRPC.generateblocks(address, 255, 1)
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.blockhashing_blob.should.be.a.String();
+                result.blocktemplate_blob.should.be.a.String();
+                block_blob = result.blocktemplate_blob;
+                result.difficulty.should.be.a.Number();
+                result.expected_reward.should.be.a.Number();
+                result.height.should.be.a.Number();
+                result.prev_hash.should.be.a.String();
+                result.reserved_offset.should.be.a.Number();
+                result.untrusted.should.be.a.Boolean();
+              })
+              .then(done, done);
+            });
+          });
+
+          // Would work, but generateblocks() doesn't do proper hashing on blocks.
+          // describe('submit_block()', () => {
+          //   it('should submit a block', done => {
+          //     daemonRPC.submit_block(block_blob)
+          //     .then(result => {
+          //       result.should.be.a.Object();
+          //       console.log(result);
+          //       result.status.should.be.a.String();
+          //       result.status.should.be.eqaul('OK');
+          //     })
+          //     .then(done, done);
+          //   });
+          // });
+
+          describe('set_bans()', () => {
+            it('should (un)ban peer', done => {
+              daemonRPC.set_bans({ host: '1.1.1.1', ban: false, seconds: 30 })
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+              })
+              .then(done, done);
+            });
+          });
+
+          describe('get_bans()', () => {
+            it('should get banned peers', done => {
+              daemonRPC.get_bans()
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                // TODO look for more information
+              })
+              .then(done, done);
+            });
+          });
+
+          describe('flush_txpool()', () => {
+            it('should flush (empty) transaction pool ("mempool")', done => {
+              daemonRPC.flush_txpool()
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+              })
+              .then(done, done);
+            });
+          });
+
+          // TODO check for empty mempool
 
           describe('set_log_hash_rate()', () => {
             it('should set hash rate log dislay mode', done => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1040,6 +1040,9 @@ describe('walletRPC constructor', () => {
                     .timeout(6000);
                   });
 
+                  // TODO sign_transfer
+                  // .. probably need to create a read-only wallet to test this.
+
                   describe('daemonRPC transfer methods constructor', () => {
                     // TODO connect to fastest daemon from test above
                     it('should connect to daemon', done => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -688,7 +688,21 @@ describe('daemonRPC constructor', () => {
                 result.peers[0].info.should.be.a.Object();
                 result.peers[0].info.address.should.be.a.String();
                 result.target_height.should.be.a.Number();
-                })
+              })
+              .then(done, done);
+            });
+          });
+
+          describe('get_output_distribution()', () => {
+            it('should get output distribution of first one hundred blocks', done => {
+              daemonRPC.get_output_distribution([17592186044415], true, 0, 10)
+              .then(result => {
+                if (typeof result == 'string')
+                  result = JSON.parse(result);
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+              })
               .then(done, done);
             });
           });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -748,6 +748,20 @@ describe('walletRPC constructor', () => {
           });
         });
 
+        describe('change_wallet_password()', () => {
+          it(`should change wallet password to 'monerojs' and back (to '')`, done => {
+            walletRPC.change_wallet_password('', 'monerojs')
+            .then(result => {
+              result.should.be.a.Object();
+              walletRPC.change_wallet_password('monerjs', '')
+              .then(result => {
+                result.should.be.a.Object();
+              })
+              .then(done, done);
+            });
+          });
+        });
+
         let height = 0;
 
         describe('get_height()', () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -635,7 +635,7 @@ describe('daemonRPC constructor', () => {
           });
 
           describe('get_coinbase_tx_sum()', () => {
-            it('should get sum of coinbase rewards for first ten blocks`', done => {
+            it('should get sum of coinbase rewards for first ten blocks', done => {
               daemonRPC.get_coinbase_tx_sum(0, 10)
               .then(result => {
                 result.should.be.a.Object();
@@ -643,6 +643,20 @@ describe('daemonRPC constructor', () => {
                 result.status.should.be.equal('OK');
                 result.emission_amount.should.be.a.Number();
                 result.fee_amount.should.be.a.Number();
+              })
+              .then(done, done);
+            });
+          });
+
+          describe('get_fee_estimate()', () => {
+            it('should get fee estimate', done => {
+              daemonRPC.get_fee_estimate(10)
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.fee.should.be.a.Number();
+                result.untrusted.should.be.a.Boolean();
               })
               .then(done, done);
             });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -662,6 +662,20 @@ describe('daemonRPC constructor', () => {
             });
           });
 
+          describe('get_alternate_chains()', () => {
+            it('should get alternate chains', done => {
+              daemonRPC.get_alternate_chains()
+              .then(result => {
+                console.log(result);
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                // TODO handle more information
+              })
+              .then(done, done);
+            });
+          });
+
           describe('set_log_hash_rate()', () => {
             it('should set hash rate log dislay mode', done => {
               daemonRPC.set_log_hash_rate(true)

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -620,6 +620,20 @@ describe('daemonRPC constructor', () => {
 
           // TODO check for empty mempool
 
+          describe('get_version()', () => {
+            it('should get daemon version', done => {
+              daemonRPC.get_version()
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.untrusted.should.be.a.Boolean();
+                result.version.should.be.a.Number();
+              })
+              .then(done, done);
+            });
+          });
+
           describe('set_log_hash_rate()', () => {
             it('should set hash rate log dislay mode', done => {
               daemonRPC.set_log_hash_rate(true)

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -747,7 +747,32 @@ describe('walletRPC constructor', () => {
           });
         });
 
-        // TODO refresh wallet
+        let height = 0;
+
+        describe('get_height()', () => {
+          it('should get wallet height', done => {
+            walletRPC.get_height()
+            .then(result => {
+              result.should.be.a.Object();
+              result.height.should.be.a.Number();
+
+              height = result.height;
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('refresh()', () => {
+          it('should refresh wallet', done => {
+            walletRPC.refresh(height)
+            .then(result => {
+              result.should.be.a.Object();
+              result.blocks_fetched.should.be.a.Number();
+              result.received_money.should.be.a.Boolean();
+            })
+            .then(done, done);
+          });
+        });
 
         let address = '';
 
@@ -761,21 +786,6 @@ describe('walletRPC constructor', () => {
               result.addresses[0].should.be.a.Object();
               result.addresses[0].address_index.should.be.a.Number();
               address = result.address;
-            })
-            .then(done, done);
-          });
-        });
-
-        let height = 0;
-
-        describe('get_height()', () => {
-          it('should get wallet height', done => {
-            walletRPC.get_height()
-            .then(result => {
-              result.should.be.a.Object();
-              result.height.should.be.a.Number();
-
-              height = result.height;
             })
             .then(done, done);
           });
@@ -843,7 +853,30 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  describe('get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   let tx_blob = '';
                   let tx_metadata = '';
@@ -1876,9 +1909,34 @@ describe('walletRPC constructor', () => {
           });
         });
 
-        let multisig_balance_22_a = 0;
+        let height = 0;
 
-        // TODO refresh wallet
+        describe('a. get_height()', () => {
+          it('should get wallet height', done => {
+            walletRPC.get_height()
+            .then(result => {
+              result.should.be.a.Object();
+              result.height.should.be.a.Number();
+
+              height = result.height;
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('a. refresh()', () => {
+          it('should refresh wallet', done => {
+            walletRPC.refresh(height)
+            .then(result => {
+              result.should.be.a.Object();
+              result.blocks_fetched.should.be.a.Number();
+              result.received_money.should.be.a.Boolean();
+            })
+            .then(done, done);
+          });
+        });
+
+        let multisig_balance_22_a = 0;
 
         describe('a. getbalance()', () => {
           it('should retrieve the 2/2 multisig wallet balance', done => {
@@ -1908,7 +1966,32 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  let height = 0;
+
+                  describe('a. get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('a. refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   describe('a. export_multisig_info()', () => {
                     it('should export multisig info', done => {
@@ -1933,7 +2016,30 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  describe('b. get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('b. refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   let address = '';
 
@@ -2373,7 +2479,32 @@ describe('walletRPC constructor', () => {
           });
         });
 
-        // TODO refresh wallet
+        let height = 0;
+
+        describe('b. get_height()', () => {
+          it('should get wallet height', done => {
+            walletRPC.get_height()
+            .then(result => {
+              result.should.be.a.Object();
+              result.height.should.be.a.Number();
+
+              height = result.height;
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('b. refresh()', () => {
+          it('should refresh wallet', done => {
+            walletRPC.refresh(height)
+            .then(result => {
+              result.should.be.a.Object();
+              result.blocks_fetched.should.be.a.Number();
+              result.received_money.should.be.a.Boolean();
+            })
+            .then(done, done);
+          });
+        });
 
         let multisig_balance_23_b = '';
 
@@ -2405,7 +2536,32 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  let height = 0;
+
+                  describe('a. get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('a. refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   describe('a. export_multisig_info()', () => {
                     it('should export multisig info', done => {
@@ -2430,7 +2586,30 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  describe('b. get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('b. refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   describe('b. export_multisig_info()', () => {
                     it('should export multisig info', done => {
@@ -2455,7 +2634,30 @@ describe('walletRPC constructor', () => {
                     });
                   });
 
-                  // TODO refresh wallet
+                  describe('c. get_height()', () => {
+                    it('should get wallet height', done => {
+                      walletRPC.get_height()
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.height.should.be.a.Number();
+
+                        height = result.height;
+                      })
+                      .then(done, done);
+                    });
+                  });
+
+                  describe('c. refresh()', () => {
+                    it('should refresh wallet', done => {
+                      walletRPC.refresh(height)
+                      .then(result => {
+                        result.should.be.a.Object();
+                        result.blocks_fetched.should.be.a.Number();
+                        result.received_money.should.be.a.Boolean();
+                      })
+                      .then(done, done);
+                    });
+                  });
 
                   let address = '';
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -742,6 +742,7 @@ describe('walletRPC constructor', () => {
             walletRPC.open_wallet(`${network}_wallet`)
             .then(result => {
               result.should.be.a.Object();
+              // error: { code: -1, message: 'Failed to open wallet' } if wallet is already open?
             })
             .then(done, done);
           });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -174,7 +174,51 @@ describe('daemonRPC constructor', () => {
           });
         });
 
-        // TODO test submitblock
+        let block_blob = '';
+
+        describe('generateblocks()', () => {
+          let address = '';
+          if (network == 'mainnet') {
+            address = '44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A';
+          } else if (network == 'testnet') {
+            address = '9sykYqd8soGa9Fv8zDMdt2gN8z2Aj5qQeBNpXjxRowkyCoWCYxa3xumYQe5MmQJuFN5CVTQwK2gqtfBNsFqa16gp1L4uGBU';
+          } else if (network == 'stagenet') {
+            address = '56Gpz2CeLbq1KT6eTHCqH43StT8kh7WQs9ji8wmECS7WUAx85FHrRztebp48wgEt6kcRbTpvBhnktEyDHVhe7xjbTAzALiY';
+          }
+
+          it('should generate a block', done => {
+            daemonRPC.generateblocks(address, 255, 1)
+            .then(result => {
+              result.should.be.a.Object();
+              result.status.should.be.a.String();
+              result.status.should.be.equal('OK');
+              result.blockhashing_blob.should.be.a.String();
+              result.blocktemplate_blob.should.be.a.String();
+              block_blob = result.blocktemplate_blob;
+              result.difficulty.should.be.a.Number();
+              result.expected_reward.should.be.a.Number();
+              result.height.should.be.a.Number();
+              result.prev_hash.should.be.a.String();
+              result.reserved_offset.should.be.a.Number();
+              result.untrusted.should.be.a.Boolean();
+            })
+            .then(done, done);
+          });
+        });
+
+        // Would work, but generateblocks() doesn't do proper hashing on blocks.
+        // describe('submit_block()', () => {
+        //   it('should submit a block', done => {
+        //     daemonRPC.submit_block(block_blob)
+        //     .then(result => {
+        //       result.should.be.a.Object();
+        //       console.log(result);
+        //       result.status.should.be.a.String();
+        //       result.status.should.be.eqaul('OK');
+        //     })
+        //     .then(done, done);
+        //   });
+        // });
 
         describe('getlastblockheader()', () => {
           it('should return block header', done => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -618,6 +618,25 @@ describe('daemonRPC constructor', () => {
             });
           });
 
+          describe('get_output_histogram()', () => {
+            it('should get output histogram', done => {
+              daemonRPC.get_output_histogram([20000000], 0, 100, false, 0)
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.histogram.should.be.a.Array();
+                result.histogram[0].should.be.a.Object();
+                result.histogram[0].amount.should.be.a.Number();
+                result.histogram[0].recent_instances.should.be.a.Number();
+                result.histogram[0].total_instances.should.be.a.Number();
+                result.histogram[0].unlocked_instances.should.be.a.Number();
+              })
+              .then(done, done);
+            })
+            .timeout(30000);
+          });
+
           // TODO check for empty mempool
 
           describe('get_version()', () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -693,6 +693,20 @@ describe('daemonRPC constructor', () => {
             });
           });
 
+          describe('get_txpool_backlog()', () => {
+            it('should get transaction pool backlog', done => {
+              daemonRPC.get_txpool_backlog()
+              .then(result => {
+                console.log(result);
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                // TODO handle more information
+              })
+              .then(done, done);
+            });
+          });
+
           describe('get_output_distribution()', () => {
             it('should get output distribution of first one hundred blocks', done => {
               daemonRPC.get_output_distribution([17592186044415], true, 0, 10)

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -427,11 +427,23 @@ describe('daemonRPC constructor', () => {
           });
         });
 
-        // TODO test send_raw_transaction
-
         describe('get_transaction_pool()', () => {
           it('should get transaction pool info', done => {
             daemonRPC.get_transaction_pool()
+            .then(result => {
+              if (typeof result == 'string')
+                result = JSON.parse(result);
+              result.should.be.a.Object();
+              result.status.should.be.a.String();
+              result.status.should.be.equal('OK');
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('get_transaction_pool_hashes()', () => {
+          it('should get hashes of transactions in pool', done => {
+            daemonRPC.get_transaction_pool_hashes()
             .then(result => {
               if (typeof result == 'string')
                 result = JSON.parse(result);
@@ -447,7 +459,8 @@ describe('daemonRPC constructor', () => {
           it('should get transaction pool stats', done => {
             daemonRPC.get_transaction_pool_stats()
             .then(result => {
-              result.should.be.a.Object();
+              if (typeof result == 'string')
+                result = JSON.parse(result);
               result.should.be.a.Object();
               result.status.should.be.a.String();
               result.status.should.be.equal('OK');

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -666,12 +666,29 @@ describe('daemonRPC constructor', () => {
             it('should get alternate chains', done => {
               daemonRPC.get_alternate_chains()
               .then(result => {
-                console.log(result);
                 result.should.be.a.Object();
                 result.status.should.be.a.String();
                 result.status.should.be.equal('OK');
                 // TODO handle more information
               })
+              .then(done, done);
+            });
+          });
+
+          describe('sync_info()', () => {
+            it('should get synchronization information', done => {
+              daemonRPC.sync_info()
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.height.should.be.a.Number();
+                result.peers.should.be.a.Array();
+                result.peers[0].should.be.a.Object();
+                result.peers[0].info.should.be.a.Object();
+                result.peers[0].info.address.should.be.a.String();
+                result.target_height.should.be.a.Number();
+                })
               .then(done, done);
             });
           });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1740,6 +1740,17 @@ describe('walletRPC constructor', () => {
           .timeout(60000);
         });
 
+        describe('get_version()', () => {
+          it('should get wallet version', done => {
+            walletRPC.get_version()
+            .then(result => {
+              result.should.be.a.Object();
+              result.version.should.be.a.Number();
+            })
+            .then(done, done);
+          });
+        });
+
         // // Destroys wallet cache
         // describe('rescan_blockchain()', () => {
         //   it('should rescan blockchain', done => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -634,6 +634,20 @@ describe('daemonRPC constructor', () => {
             });
           });
 
+          describe('get_coinbase_tx_sum()', () => {
+            it('should get sum of coinbase rewards for first ten blocks`', done => {
+              daemonRPC.get_coinbase_tx_sum(0, 10)
+              .then(result => {
+                result.should.be.a.Object();
+                result.status.should.be.a.String();
+                result.status.should.be.equal('OK');
+                result.emission_amount.should.be.a.Number();
+                result.fee_amount.should.be.a.Number();
+              })
+              .then(done, done);
+            });
+          });
+
           describe('set_log_hash_rate()', () => {
             it('should set hash rate log dislay mode', done => {
               daemonRPC.set_log_hash_rate(true)

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -806,6 +806,38 @@ describe('walletRPC constructor', () => {
           });
         });
 
+        let subaddress = '';
+        let address_index = 0;
+
+        describe('create_address()', () => {
+          it('should create new subaddress', done => {
+            walletRPC.create_address(0, 'monerojs unit test suite')
+            .then(result => {
+              result.should.be.a.Object();
+              result.address.should.be.a.String();
+              subaddress = result.address;
+              result.address_index.should.be.a.Number();
+              address_index = result.address_index;
+            })
+            .then(done, done);
+          });
+        });
+
+        describe('get_address_index()', () => {
+          it('should return the index of the wallet subaddress that was just created', done => {
+            walletRPC.get_address_index(subaddress)
+            .then(result => {
+              result.should.be.a.Object();
+              result.index.should.be.a.Object();
+              result.index.major.should.be.a.Number();
+              result.index.major.should.be.equal(0);
+              result.index.minor.should.be.a.Number();
+              result.index.minor.should.be.equal(address_index);
+            })
+            .then(done, done);
+          });
+        });
+
         let key_images = [];
 
         describe('export_key_images()', () => {
@@ -1346,21 +1378,6 @@ describe('walletRPC constructor', () => {
                   });
                 }
               });
-            })
-            .then(done, done);
-          });
-        });
-
-        let address_index = 0;
-
-        describe('create_address()', () => {
-          it('should create new subaddress', done => {
-            walletRPC.create_address(0, 'monerojs unit test suite')
-            .then(result => {
-              result.should.be.a.Object();
-              result.address.should.be.a.String();
-              result.address_index.should.be.a.Number();
-              address_index = result.address_index;
             })
             .then(done, done);
           });


### PR DESCRIPTION
this pull request adds some methods from 0.13.x, which hasn't been tagged yet and thus we can't be sure that more won't be necessary.  for now, though, this should be *most* of the new RPC methods that end up in 0.13